### PR TITLE
Rename EN TOC menu name for API Documentations

### DIFF
--- a/content/toc_en.json
+++ b/content/toc_en.json
@@ -352,7 +352,7 @@
       "desc": "Introduction to KubeSphere API",
       "chapters": [
         {
-          "title": "API Guide",
+          "title": "API Documentation",
           "entry": "/en/api-reference/api-docs"
         },
         {


### PR DESCRIPTION
The name `API Guide` seems not following the usual naming conventions within docs. This PR is going to change it.

Signed-off-by: imjoey <majunjiev@gmail.com>